### PR TITLE
Enable/Disable action progressive widening

### DIFF
--- a/src/POMCP.jl
+++ b/src/POMCP.jl
@@ -11,6 +11,8 @@ import GenerativeModels
 import StatsBase: WeightVec, sample
 import MCTS: ActionGenerator, RandomActionGenerator
 
+using Compat
+
 export
     POMCPSolver,
     POMCPDPWSolver,

--- a/src/POMCP.jl
+++ b/src/POMCP.jl
@@ -11,8 +11,6 @@ import GenerativeModels
 import StatsBase: WeightVec, sample
 import MCTS: ActionGenerator, RandomActionGenerator
 
-using Compat
-
 export
     POMCPSolver,
     POMCPDPWSolver,
@@ -80,6 +78,8 @@ type POMCPDPWSolver <: POMDPs.Solver
     value_estimate_method::Symbol # :rollout or :value
     rollout_solver::Union{POMDPs.Solver, POMDPs.Policy}
 
+    enable_action_pw::Bool
+
     alpha_observation::Float64
     k_observation::Float64
     alpha_action::Float64
@@ -113,7 +113,7 @@ include("visualization.jl")
 """
 Return a list of methods required to use POMCP
 """
-function required_methods() 
+function required_methods()
     return [
         POMDPs.iterator,
         POMDPs.actions,

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -47,6 +47,7 @@ POMCPSolver properties are:
 - `node_belief_updater` - A `POMDPs.Updater` to be used to update the belief in the nodes of the belief tree. By default the particle filter described in the paper will be used.
 - `value_estimate_method` - Either `:value` to use the `POMDPs.value()` function or `:rollout` to use a rollout simulation.
 - `rollout_solver` - This should be a `POMDPs.Solver` or `POMDPs.Policy` that will be used in rollout simulations. If it is a `Solver`, `solve` will be called to determine the rollout policy. By default a random policy is used.
+- `enable_action_pw` - Enable or not the prograssive widening of the number of action node. default: true
 - `alpha_observation` - Exponent parameter for progressive widening of the number of observation nodes. default: 0.5
 - `k_observation` - Linear parameter for progressive widening of the number of observation nodes. default: 10.0
 - `alpha_action` - Exponent parameter for progressive widening of the number of action nodes. default: 0.5
@@ -63,6 +64,7 @@ function POMCPDPWSolver(;eps=0.01,
                       node_belief_updater=DefaultReinvigoratorStub(),
                       value_estimate_method=:rollout,
                       rollout_solver=POMDPToolbox.RandomSolver(),
+                      enable_action_pw=true,
                       alpha_observation::Float64=0.5,
                       k_observation::Float64=10.,
                       alpha_action::Float64=0.5,
@@ -77,6 +79,7 @@ function POMCPDPWSolver(;eps=0.01,
                        node_belief_updater,
                        value_estimate_method,
                        rollout_solver,
+                       enable_action_pw,
                        alpha_observation,
                        k_observation,
                        alpha_action,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,8 +31,17 @@ solver = POMCPSolver(rollout_solver=FeedWhenCrying(),
 
 @test_throws ErrorException test_solver(solver, BabyPOMDP(), max_steps=100)
 
+# test for DPW
 solver = POMCPDPWSolver(tree_queries=100)
 
+test_solver(solver,BabyPOMDP())
+
+# test for enable/disable action pw
+solver = POMCPDPWSolver(tree_queries=100,
+                     eps=0.01,
+                     c=10.0,
+                     enable_action_pw=false,
+                     rng =MersenneTwister(2))
 test_solver(solver,BabyPOMDP())
 
 include("visualization.jl")


### PR DESCRIPTION
A new feature to the POMCPDPW solver. 
If you add 

> enable_action_pw=false

when initializing the solver, it will do PW on observations only and will loop through all the action when exploring a new state (just as regular POMCP). It is for discrete action spaces only.